### PR TITLE
Pin black to current version in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
           name: configure conda
           command: |
               export PATH="$HOME/miniconda/bin:$PATH"
-              pip install black
+              pip install black==18.9b0
       - save_cache:
           key: miniconda-v1-black
           paths:

--- a/news/pin-black-in-ci.rst
+++ b/news/pin-black-in-ci.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* Circle CI config updated to use a pinned version of ``black`` (18.9b0)
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
Resolves #2846 by updating CircleCI config to explicitly use version 18.9b0 (latest at the time of this writing).